### PR TITLE
pickle 存取 bytes类型

### DIFF
--- a/src/python/3.DecisionTree/DecisionTree.py
+++ b/src/python/3.DecisionTree/DecisionTree.py
@@ -318,13 +318,13 @@ def storeTree(inputTree, filename):
     """
     import pickle
     # -------------- 第一种方法 start --------------
-    fw = open(filename, 'w')
+    fw = open(filename, 'wb')
     pickle.dump(inputTree, fw)
     fw.close()
     # -------------- 第一种方法 end --------------
 
     # -------------- 第二种方法 start --------------
-    with open(filename, 'w') as fw:
+    with open(filename, 'wb') as fw:
         pickle.dump(inputTree, fw)
     # -------------- 第二种方法 start --------------
 
@@ -339,7 +339,7 @@ def grabTree(filename):
         pickle.load(fr) -- 将之前存储的决策树模型还原出来
     """
     import pickle
-    fr = open(filename)
+    fr = open(filename, 'rb')
     return pickle.load(fr)
 
 


### PR DESCRIPTION
pickle存取需要用字节类型，具体为啥我也不知道。不过我试了下，确实需要用字节才能正确运营。