### PR TITLE
Travis CI: Add automated tests to find syntax errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,28 @@
+group: travis_latest
+language: python
+cache: pip
+python:
+  - 2.7
+  - 3.7
+matrix:
+  allow_failures:
+    - python: 2.7
+  include:
+    - python: 2.7
+      env: TEST_DIR=./MachineLearning/src/py2.x,
+    - python: 3.7
+      env: TEST_DIR=./MachineLearning/src/py3.x/
+      dist: xenial    # required for Python 3.7
+      sudo: required  # required for Python 3.7
+install:
+  - pip install flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 ${TEST_DIR} --count --select=E901,E999,F821,F822,F823 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 ${TEST_DIR} --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+script:
+  - true  # add other tests here
+notifications:
+  on_success: change
+  on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Use [flake8](http://flake8.pycqa.org) to look for Python syntax errors or undefined names on both Python 2.7 and Python 3.7.

__E901,E999,F821,F822,F823__ are the "showstopper" flake8 issues that can halt the runtime with a SyntaxError, NameError, etc.  Most other flake8 issues are merely "style violations" -- useful for readability but they do not effect runtime safety.  This PR therefore recommends a flake8 run of these tests on the entire codebase.
* F821: undefined name `name`
* F822: undefined name `name` in `__all__`
* F823: local variable `name` referenced before assignment
* E901: SyntaxError or IndentationError
* E999: SyntaxError -- failed to compile a file into an Abstract Syntax Tree