### PR TITLE
Update 7.md

### DIFF
--- a/docs/ml/7.md
+++ b/docs/ml/7.md
@@ -156,7 +156,7 @@ def cross_validation_split(dataset, n_folds):
     fold_size = len(dataset) / n_folds
     for i in range(n_folds):
         fold = list()                  # 每次循环 fold 清零，防止重复导入 dataset_split
-        while len(fold) < fold_size:   # 这里不能用 if，if 只是在第一次判断时起作用，while 执行循环，直到条件不成立
+        while len(fold) < fold_size and len(dataset_copy) > 0:   # 这里不能用 if，if 只是在第一次判断时起作用，while 执行循环，直到条件不成立
             # 有放回的随机采样，有一些样本被重复采样，从而在训练集中多次出现，有的则从未在训练集中出现，此为自助采样法。从而保证每棵决策树训练集的差异性            
             index = randrange(len(dataset_copy))
             # 将对应索引 index 的内容从 dataset_copy 中导出，并将该内容从 dataset_copy 中删除。


### PR DESCRIPTION
如果不限制dataset_copy的中元素数量的话，会报错
Traceback (most recent call last):
  File "F:\桌面\machine_learning\Random_Forest\random_forest.py", line 70, in <module>
    dataset_split = cross_validation_split(dataset, 5)
  File "F:\桌面\machine_learning\Random_Forest\random_forest.py", line 59, in cross_validation_split
    index = random.randrange(len(dataset_copy))
  File "E:\anaconda\envs\AI\lib\random.py", line 306, in randrange
    raise ValueError("empty range for randrange()")
ValueError: empty range for randrange()